### PR TITLE
更新power及修复启迪的bug等

### DIFF
--- a/src/main/java/rs/wolf/theastray/abstracts/AstrayPower.java
+++ b/src/main/java/rs/wolf/theastray/abstracts/AstrayPower.java
@@ -1,0 +1,156 @@
+package rs.wolf.theastray.abstracts;
+
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.localization.PowerStrings;
+import rs.lazymankits.abstracts.LMCustomPower;
+import rs.wolf.theastray.utils.TAUtils;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class AstrayPower extends LMCustomPower implements TAUtils {
+    @FunctionalInterface
+    public interface PreloadPowerStringFunction {
+        void pre(String[] rawString);
+    }
+    
+    public static final Pattern POWER_NAME = Pattern.compile("\\[(owner)]", Pattern.MULTILINE);
+    public static final Pattern POWER_AMT = Pattern.compile("\\[(amt_(\\d))]", Pattern.MULTILINE);
+    public static final Pattern POWER_TARGET = Pattern.compile("\\[(crt_(\\d))]", Pattern.MULTILINE);
+    
+    private static final PowerStrings PwrStrings = TAUtils.PowerStrings(TAUtils.MakeID("AstrayPower"));
+    private PreloadPowerStringFunction func = null;
+    protected PowerStrings powerStrings;
+    protected String NAME;
+    protected String[] DESCRIPTIONS;
+    private String owner_name;
+    private String[] crt_names;
+    private String[] amts;
+    
+    public AstrayPower(String ID, String img, PowerType type, AbstractCreature owner) {
+        this.ID = ID;
+        this.type = type;
+        this.owner = owner;
+        crt_names = new String[3];
+        amts = new String[3];
+        Arrays.fill(crt_names, "missing_name");
+        Arrays.fill(amts, "missing_value");
+        initLocals();
+        loadImg(img);
+    }
+    
+    protected void initLocals() {
+        powerStrings = TAUtils.PowerStrings(ID);
+        NAME = powerStrings.NAME;
+        DESCRIPTIONS = powerStrings.DESCRIPTIONS;
+        this.name = NAME;
+    }
+    
+    protected void preloadString(PreloadPowerStringFunction func) {
+        this.func = func;
+    }
+    
+    protected String getString() {
+        String[] rawString = new String[] {DESCRIPTIONS[0]};
+        if (func != null) func.pre(rawString);
+        return rawString[0];
+    }
+    
+    @Override
+    protected void loadImg(String name) {
+        if (getPowerAtlas() != null) super.loadImg(name);
+        if (region128 == null || region48 == null)
+            loadRegion(name);
+    }
+    
+    protected void setValues(int amount) {
+        super.setValues(owner, null, amount);
+        setOwnerName();
+    }
+    
+    protected void setValues(int amount, int extraAmt) {
+        super.setValues(owner, null, amount, extraAmt);
+        setOwnerName();
+    }
+    
+    protected void setValues(AbstractCreature source, int amount) {
+        super.setValues(owner, source, amount);
+        setOwnerName();
+    }
+    
+    protected void setValues(AbstractCreature source, int amount, int extraAmt) {
+        super.setValues(owner, source, amount, extraAmt);
+        setOwnerName();
+    }
+    
+    protected void setOwnerName() {
+        owner_name = owner.isPlayer ? PwrStrings.DESCRIPTIONS[0] : owner.name;
+    }
+    
+    protected void setAmtValue(int slot, int value) {
+        if (slot > amts.length - 1)
+            slot = amts.length - 1;
+        amts[slot] = String.valueOf(value);
+    }
+    
+    protected void setAmtValue(int slot, float value) {
+        if (slot > amts.length - 1)
+            slot = amts.length - 1;
+        amts[slot] = String.valueOf(value);
+    }
+    
+    protected void setCrtName(int slot, String value) {
+        if (slot > crt_names.length - 1)
+            slot = crt_names.length - 1;
+        crt_names[slot] = value;
+    }
+    
+    @Override
+    public void updateDescription() {
+        String rawString = getString();
+        description = checkWithPatterns(rawString);
+    }
+    
+    protected String checkWithPatterns(String origin) {
+        origin = checkOwnerName(origin);
+        origin = checkAmtValue(origin);
+        origin = checkCrtValue(origin);
+        return origin;
+    }
+    
+    private String checkAmtValue(String origin) {
+        final Matcher matcher = POWER_AMT.matcher(origin);
+        while (matcher.find() && matcher.groupCount() >= 2) {
+            int slot = Integer.parseInt(matcher.group(2));
+            if (slot <= amts.length - 1) {
+                origin = origin.replace(matcher.group(0), amts[slot]);
+            }
+        }
+        return origin;
+    }
+    
+    private String checkCrtValue(String origin) {
+        final Matcher matcher = POWER_TARGET.matcher(origin);
+        while (matcher.find() && matcher.groupCount() >= 2) {
+            int slot = Integer.parseInt(matcher.group(2));
+            if (slot <= crt_names.length - 1) {
+                origin = origin.replace(matcher.group(0), crt_names[slot]);
+            }
+        }
+        return origin;
+    }
+    
+    private String checkOwnerName(String origin) {
+        final Matcher matcher = POWER_NAME.matcher(origin);
+        if (matcher.find())
+            origin = origin.replace(matcher.group(0), owner_name);
+        return origin;
+    }
+    
+    @Override
+    protected TextureAtlas getPowerAtlas() {
+        return null;
+    }
+}

--- a/src/main/java/rs/wolf/theastray/cards/AstrayExtCard.java
+++ b/src/main/java/rs/wolf/theastray/cards/AstrayExtCard.java
@@ -4,6 +4,9 @@ import rs.wolf.theastray.abstracts.AstrayCard;
 import rs.wolf.theastray.data.DataMst;
 import rs.wolf.theastray.patches.TACardEnums;
 
+/**
+ * 扩展牌继承该抽象类
+ */
 public abstract class AstrayExtCard extends AstrayCard {
     public AstrayExtCard(int index, int cost, int extNeed, CardTarget target) {
         super(DataMst.Get(index), cost, TACardEnums.TAE_CardColor, target);

--- a/src/main/java/rs/wolf/theastray/cards/AstrayProCard.java
+++ b/src/main/java/rs/wolf/theastray/cards/AstrayProCard.java
@@ -4,6 +4,9 @@ import rs.wolf.theastray.abstracts.AstrayCard;
 import rs.wolf.theastray.data.DataMst;
 import rs.wolf.theastray.patches.TACardEnums;
 
+/**
+ * 角色职业牌继承该抽象类
+ */
 public abstract class AstrayProCard extends AstrayCard {
     public AstrayProCard(int index, int cost, CardTarget target) {
         super(DataMst.Get(index), cost, TACardEnums.TA_CardColor, target);

--- a/src/main/java/rs/wolf/theastray/cards/pros/B3.java
+++ b/src/main/java/rs/wolf/theastray/cards/pros/B3.java
@@ -4,6 +4,7 @@ import com.megacrit.cardcrawl.actions.AbstractGameAction;
 import com.megacrit.cardcrawl.core.AbstractCreature;
 import rs.lazymankits.interfaces.cards.UpgradeBranch;
 import rs.wolf.theastray.cards.AstrayProCard;
+import rs.wolf.theastray.powers.BurntPower;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,11 +20,15 @@ public class B3 extends AstrayProCard {
     @Override
     public void play(AbstractCreature s, AbstractCreature t) {
         addToBot(DamageAction(t, s, AbstractGameAction.AttackEffect.FIRE));
+        if (finalBranch() == 1) { // 用 finalBranch 来判断真正的分支
+            // 用 burnt(int, AbstractCreature) 来获取余烬的层数
+            addToBot(ApplyPower(t, s, new BurntPower(t, s, burnt(magicNumber, t))));
+        }
     }
     
     @Override
     public void selfUpgrade() {
-        upgradeWithChosenBranch();
+        branchingUpgrade();
     }
     
     @Override

--- a/src/main/java/rs/wolf/theastray/commands/Cheat.java
+++ b/src/main/java/rs/wolf/theastray/commands/Cheat.java
@@ -1,0 +1,10 @@
+package rs.wolf.theastray.commands;
+
+public class Cheat {
+    protected static final boolean[] CHEATS = new boolean[] {false, false, false, false, false};
+    public static final int IEL = 0; // IgnoredEnlightenLimitation
+    
+    public static boolean IsCheating(int index) {
+        return index < CHEATS.length && CHEATS[index];
+    }
+}

--- a/src/main/java/rs/wolf/theastray/commands/CheatCMD.java
+++ b/src/main/java/rs/wolf/theastray/commands/CheatCMD.java
@@ -1,0 +1,31 @@
+package rs.wolf.theastray.commands;
+
+import basemod.DevConsole;
+import basemod.devcommands.ConsoleCommand;
+
+public class CheatCMD extends ConsoleCommand {
+    @Override
+    protected void execute(String[] tokens, int i) {
+        if (tokens.length < 1) {
+            cmdEnergyHelp();
+            return;
+        }
+        if (tokens[1].equalsIgnoreCase("Enlightened") && tokens.length > 2) {
+            boolean enabled = Boolean.parseBoolean(tokens[2]);
+            Cheat.CHEATS[Cheat.IEL] = enabled;
+            DevConsole.log("Enlightened: " + Cheat.IsCheating(Cheat.IEL));
+        } else {
+            cmdEnergyHelp();
+        }
+    }
+    
+    @Override
+    protected void errorMsg() {
+        cmdEnergyHelp();
+    }
+    
+    private static void cmdEnergyHelp() {
+        DevConsole.couldNotParse();
+        DevConsole.log("If you don't know how to cheat, don't cheat.");
+    }
+}

--- a/src/main/java/rs/wolf/theastray/core/Leader.java
+++ b/src/main/java/rs/wolf/theastray/core/Leader.java
@@ -10,10 +10,12 @@ import com.google.gson.Gson;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.localization.CharacterStrings;
 import com.megacrit.cardcrawl.localization.Keyword;
+import com.megacrit.cardcrawl.localization.PowerStrings;
 import org.jetbrains.annotations.NotNull;
 import rs.lazymankits.LMDebug;
 import rs.lazymankits.utils.LMSK;
 import rs.wolf.theastray.characters.BlueTheAstray;
+import rs.wolf.theastray.commands.CheatCMD;
 import rs.wolf.theastray.commands.ManaCMD;
 import rs.wolf.theastray.data.DataMst;
 import rs.wolf.theastray.localizations.TALocalLoader;
@@ -57,6 +59,7 @@ public class Leader implements TAUtils, EditStringsSubscriber, EditKeywordsSubsc
         TALocalLoader.Initialize();
         String lang = getSupLang();
         BaseMod.loadCustomStringsFile(CharacterStrings.class, "AstrayAssets/locals/" + lang + "/chars.json");
+        BaseMod.loadCustomStringsFile(PowerStrings.class, "AstrayAssets/locals/" + lang + "/powers.json");
     }
     
     @Override
@@ -87,6 +90,7 @@ public class Leader implements TAUtils, EditStringsSubscriber, EditKeywordsSubsc
     @Override
     public void receivePostInitialize() {
         ConsoleCommand.addCommand("bluemana", ManaCMD.class);
+        ConsoleCommand.addCommand("bluecheat", CheatCMD.class);
     }
     
     @Override

--- a/src/main/java/rs/wolf/theastray/data/CardData.java
+++ b/src/main/java/rs/wolf/theastray/data/CardData.java
@@ -2,6 +2,7 @@ package rs.wolf.theastray.data;
 
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import org.jetbrains.annotations.NotNull;
+import rs.wolf.theastray.utils.TAUtils;
 
 public class CardData {
     private final String ID;
@@ -16,7 +17,11 @@ public class CardData {
         this.rarity = rarity;
     }
     
-    public String getID() {
+    public String getCardID() {
+        return TAUtils.MakeID(ID);
+    }
+    
+    public String getInternalID() {
         return ID;
     }
     

--- a/src/main/java/rs/wolf/theastray/data/DataMst.java
+++ b/src/main/java/rs/wolf/theastray/data/DataMst.java
@@ -31,7 +31,7 @@ public class DataMst {
     }
     
     public static String ID(int index) {
-        if (DataIndexMap.containsKey(index)) return DataIndexMap.get(index).getID();
+        if (DataIndexMap.containsKey(index)) return DataIndexMap.get(index).getCardID();
         TAUtils.Log("UNDEFINED INDEX: [" + index + "]");
         return "UNDEFINED";
     }
@@ -43,7 +43,7 @@ public class DataMst {
     }
     
     public static String ID(String localname) {
-        if (DataNameMap.containsKey(localname)) return DataNameMap.get(localname).getID();
+        if (DataNameMap.containsKey(localname)) return DataNameMap.get(localname).getCardID();
         TAUtils.Log("UNDEFINED LOCAL NAME: [" + localname + "]");
         return "UNDEFINED";
     }

--- a/src/main/java/rs/wolf/theastray/powers/BurntPower.java
+++ b/src/main/java/rs/wolf/theastray/powers/BurntPower.java
@@ -1,0 +1,67 @@
+package rs.wolf.theastray.powers;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.LoseHPAction;
+import com.megacrit.cardcrawl.actions.common.RemoveSpecificPowerAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import rs.lazymankits.actions.CustomDmgInfo;
+import rs.wolf.theastray.abstracts.AstrayPower;
+import rs.wolf.theastray.patches.TACardEnums;
+import rs.wolf.theastray.utils.TAUtils;
+
+public class BurntPower extends AstrayPower {
+    public static final String ID = TAUtils.MakeID("BurntPower");
+    
+    public BurntPower(AbstractCreature owner, AbstractCreature source, int amount) {
+        super(ID, "combust", PowerType.DEBUFF, owner);
+        setValues(source, amount);
+        preloadString((s) -> checkValues());
+        updateDescription();
+    }
+    
+    private void checkValues() {
+        setAmtValue(0, amount);
+        extraAmt = 1;
+        if (owner instanceof AbstractMonster && ((AbstractMonster) owner).getIntentBaseDmg() > 0) {
+            extraAmt *= 2;
+        }
+        setAmtValue(1, extraAmt);
+    }
+    
+    @Override
+    public void atStartOfTurn() {
+        super.atStartOfTurn();
+        if (amount > 0) {
+            addToBot(new LoseHPAction(owner, source, amount, AbstractGameAction.AttackEffect.FIRE));
+            addToBot(new RemoveSpecificPowerAction(owner, owner, this));
+        }
+    }
+    
+    @Override
+    public void atEndOfTurn(boolean isPlayer) {
+        super.atEndOfTurn(isPlayer);
+        updateDescription();
+    }
+    
+    @Override
+    public int onAttacked(DamageInfo info, int damageAmount) {
+        if (info != null && info instanceof CustomDmgInfo && info.owner == source) {
+            AbstractCard sourceCard = ((CustomDmgInfo) info).source.getCardFrom();
+            if (sourceCard != null && sourceCard.hasTag(TACardEnums.MAGICAL)) {
+                checkValues();
+                addToTop(new ApplyPowerAction(owner, owner, this, extraAmt));
+            }
+        }
+        return super.onAttacked(info, damageAmount);
+    }
+    
+    @Override
+    public AbstractPower makeCopy() {
+        return new BurntPower(owner, source, amount);
+    }
+}

--- a/src/main/java/rs/wolf/theastray/powers/FrostPower.java
+++ b/src/main/java/rs/wolf/theastray/powers/FrostPower.java
@@ -1,0 +1,68 @@
+package rs.wolf.theastray.powers;
+
+import com.badlogic.gdx.math.MathUtils;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.common.ReducePowerAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.DamageInfo;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import rs.lazymankits.actions.CustomDmgInfo;
+import rs.wolf.theastray.abstracts.AstrayPower;
+import rs.wolf.theastray.patches.TACardEnums;
+import rs.wolf.theastray.utils.TAUtils;
+
+public class FrostPower extends AstrayPower {
+    public static final String ID = TAUtils.MakeID("FrostPower");
+    
+    public FrostPower(AbstractCreature owner, AbstractCreature source, int amount) {
+        super(ID, "int", PowerType.DEBUFF, owner);
+        setValues(source, amount);
+        updateDescription();
+    }
+    
+    @Override
+    public float atDamageFinalGive(float damage, DamageInfo.DamageType type) {
+        if (type == DamageInfo.DamageType.NORMAL && amount > 0 && damage <= amount)
+            damage = 0;
+        return super.atDamageFinalGive(damage, type);
+    }
+    
+    @Override
+    public int onAttackToChangeDamage(DamageInfo info, int damageAmount) {
+        if (info.type == DamageInfo.DamageType.NORMAL && amount > 0) {
+            if (damageAmount <= amount && damageAmount > 0) {
+                Log("??? How is possible: " + damageAmount);
+                damageAmount = 0;
+            }
+        }
+        return super.onAttackToChangeDamage(info, damageAmount);
+    }
+    
+    @Override
+    public void atEndOfTurn(boolean isPlayer) {
+        super.atEndOfTurn(isPlayer);
+        if (amount > 0) {
+            addToBot(new ReducePowerAction(owner, owner, this, MathUtils.ceil(amount / 2F)));
+        }
+    }
+    
+    @Override
+    public int onAttacked(DamageInfo info, int damageAmount) {
+        boolean useMagic = !(info instanceof CustomDmgInfo);
+        if (info != null && info instanceof CustomDmgInfo && info.owner == source) {
+            AbstractCard sourceCard = ((CustomDmgInfo) info).source.getCardFrom();
+            if (sourceCard != null && sourceCard.hasTag(TACardEnums.MAGICAL)) {
+                useMagic = true;
+            }
+        }
+        if (!useMagic)
+            addToTop(new ReducePowerAction(owner, owner, this, 1));
+        return super.onAttacked(info, damageAmount);
+    }
+    
+    @Override
+    public AbstractPower makeCopy() {
+        return new FrostPower(owner, source, amount);
+    }
+}

--- a/src/main/java/rs/wolf/theastray/utils/TAUtils.java
+++ b/src/main/java/rs/wolf/theastray/utils/TAUtils.java
@@ -1,7 +1,10 @@
 package rs.wolf.theastray.utils;
 
+import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.core.Settings;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.localization.PowerStrings;
+import com.megacrit.cardcrawl.localization.UIStrings;
 import com.megacrit.cardcrawl.rooms.AbstractRoom;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -67,5 +70,17 @@ public interface TAUtils extends LMGameGeneralUtils {
     @NotNull
     static String CardImage(int localID) {
         return "AstrayAssets/images/cardports/" + localID + ".png";
+    }
+    
+    static UIStrings UIStrings(@NotNull String id) {
+        if (!id.startsWith(GetPrefix()))
+            id = MakeID(id);
+        return CardCrawlGame.languagePack.getUIString(id);
+    }
+    
+    static PowerStrings PowerStrings(@NotNull String id) {
+        if (!id.startsWith(GetPrefix()))
+            id = MakeID(id);
+        return CardCrawlGame.languagePack.getPowerStrings(id);
     }
 }

--- a/src/main/resources/AstrayAssets/locals/zhs/powers.json
+++ b/src/main/resources/AstrayAssets/locals/zhs/powers.json
@@ -1,0 +1,22 @@
+{
+  "astray:AstrayPower": {
+    "NAME": "能力",
+    "DESCRIPTIONS": [
+      "你"
+    ]
+  },
+
+  "astray:BurntPower": {
+    "NAME": "余烬",
+    "DESCRIPTIONS": [
+      "#y[owner] 在其回合开始时失去 #b[amt_0] 点生命值和所有 #y余烬 。受到 #y魔法 牌的伤害后， #y余烬  增加 #b[amt_1] 层。"
+    ]
+  },
+
+  "astray:FrostPower": {
+    "NAME": "冰霜",
+    "DESCRIPTIONS": [
+      "#y[owner] 造成的伤害减少 #b[amt_0] 点。在其回合结束时， #y冰霜 减半。在受到 #r非 #y魔法 牌的伤害后， #y冰霜 减少 #b1 层。"
+    ]
+  }
+}


### PR DESCRIPTION
1. 添加了AstrayPower抽象类，所有的power均继承该类；
2. 添加了余烬和冰霜的power，分别为BurntPower和FrostPower；
3. 修复了启迪升级时因情况不同导致分支列表发生变化，进而导致升级到错误分支的bug；
4. 新添作弊码，bluecheat enlightened true/false ，用于开启/关闭启“忽略迪牌升级的限制条件”